### PR TITLE
Support for apache 2.2

### DIFF
--- a/templates/adminer.conf.j2
+++ b/templates/adminer.conf.j2
@@ -1,4 +1,9 @@
 Alias /adminer "{{ adminer_install_dir }}/adminer.php"
 <Directory "{{ adminer_install_dir }}">
+{% if apache_vhosts_version == "2.2" %}
+    Order allow,deny
+    Allow from all
+{% else %} 
     Require all granted
+{% endif %}
 </Directory>


### PR DESCRIPTION
When using this role with the geerlingguy.apache role and an Apache 2.2 setup you get the error: **configuration error:  couldn't perform authentication. AuthType not set!: /adminer**
This PR attempts to fix that.
