### PR TITLE
Rebased version of #9 -- forcing adminer download if script is older then 1 day, also adds theme support as well.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Directories inside which you would like `adminer.php` symlinked. Can be useful i
 
 Set this to `true` to tell Adminer to add a config file to Apache so you can access it at `hostname/adminer` on any configured virtualhost, using an Apache `Alias` directive. The role will also restart Apache so this configuration takes effect immediately.
 
+    adminer_theme: ''
+
+You can use any theme from adminer library (for example `pappu687`). You can find the full list [here](https://www.adminer.org/en/#extras).
+
 ## Dependencies
 
 None. If `adminer_add_apache_config` is set to `true`, it will use some variables and handlers defined by the `geerlingguy.apache` role, so there's a soft dependency on that role.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,12 +6,27 @@
     state: directory
     recurse: true
 
+- name: Testing if adminer is older then 1 day
+  find:
+    paths: "{{ adminer_install_dir }}"
+    patterns: "{{ adminer_install_filename }}"
+    age: "1d"
+  register: adminer_is_old
+
 - name: Download Adminer to configured directory.
   get_url:
     url: https://www.adminer.org/latest.php
     dest: "{{ adminer_install_dir }}/{{ adminer_install_filename }}"
+    force: "{{ (adminer_is_old.matched == 1) | ternary('yes','no') }}"
     mode: 0644
     timeout: 60
+
+- name: Ensure paths to place symlinks exist
+  file:
+    state: directory
+    path: "{{ item }}"
+  with_items:
+    - "{{ adminer_symlink_dirs }}"
 
 - name: Symlink Adminer into configured directories.
   file:
@@ -19,6 +34,24 @@
     dest: "{{ item }}/adminer.php"
     state: link
   with_items: "{{ adminer_symlink_dirs }}"
+
+# Install Adminer theme.
+- name: Download Adminer theme
+  get_url:
+    url: https://raw.githubusercontent.com/vrana/adminer/master/designs/{{ adminer_theme }}/adminer.css
+    dest: "{{ adminer_install_dir }}"
+    force: "{{ (adminer_is_old.matched == 1) | adminer_force_download }}"
+    mode: 0644
+    timeout: 60
+  when: adminer_theme is defined and adminer_theme != null
+
+- name: Symlink Adminer theme into configured directories.
+  file:
+    src: "{{ adminer_install_dir }}/adminer.css"
+    dest: "{{ item }}/adminer.css"
+    state: link
+  with_items: "{{ adminer_symlink_dirs }}"
+  when: adminer_theme is defined and adminer_theme != null
 
 # Add Apache configuration (if configured).
 - name: Set the proper Apache configuration directory (Debian).


### PR DESCRIPTION
This is a squashed version of #9 -- literally just squashed all commits. 

Quoting mostly from #9: 
> This PR adds:
> 
> - support for optional css styling
> - a test on the age of the adminer.css file and forced download if this age is > 1 day and similarly for adminer.php
> - Hope this is fit for inclusion.